### PR TITLE
docs: auto-generate EDoc and deploy via GitHub Pages

### DIFF
--- a/.github/workflows/erlang-tests.yml
+++ b/.github/workflows/erlang-tests.yml
@@ -106,6 +106,24 @@ jobs:
           name: coverage-otp-26
           path: public                       # GitHub Pages expects this dir
 
+      # Build HTML API docs and place them under public/edoc so that
+      # the coverage report (index.html at the root) remains
+      # the entry-point of the site.
+      - name: Checkout repository (for docs)
+        uses: actions/checkout@v3
+
+      - name: Set up Erlang/OTP (for docs)
+        uses: erlef/setup-beam@v1
+        with:
+          otp-version: 26
+          rebar3-version: ${{ env.REBAR3_VERSION }}
+
+      - name: Generate EDoc documentation
+        run: |
+          rebar3 edoc
+          mkdir -p public/edoc
+          cp -r doc/* public/edoc/
+
       - name: Setup Pages
         uses: actions/configure-pages@v5
 

--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ _build
 *.iml
 rebar3.crashdump
 *~
+doc/

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 [![Erlang CI](https://github.com/ts-klassen/klsn/actions/workflows/erlang-tests.yml/badge.svg?branch=main)](https://github.com/ts-klassen/klsn/actions/workflows/erlang-tests.yml)
 [Coverage report](https://ts-klassen.github.io/klsn/)
+[API docs](https://ts-klassen.github.io/klsn/edoc/)
 
 
 


### PR DESCRIPTION
* Add API docs link in README
* Ignore generated doc directory
* Extend workflow to build & publish EDoc under /edoc/ while keeping coverage at root