### PR TITLE
extend urlencode to 0-255

### DIFF
--- a/src/klsn_binstr.erl
+++ b/src/klsn_binstr.erl
@@ -85,6 +85,9 @@ urlencode(<<Char/utf8, Rest/binary>>, IsSafe, Acc) ->
             <<Char/utf8>>
     end,
     urlencode(Rest, IsSafe, <<Acc/binary, Encoded/binary>>);
+urlencode(<<Char:1/binary, Rest/binary>>, IsSafe, Acc) ->
+    Encoded = percent_encode(<<Char/binary>>, <<>>),
+    urlencode(Rest, IsSafe, <<Acc/binary, Encoded/binary>>);
 urlencode(_, _, _) ->
     error(badarg).
 

--- a/test/klsn_binstr_tests.erl
+++ b/test/klsn_binstr_tests.erl
@@ -21,12 +21,21 @@ urlencode_1_test() ->
     %% Test encoding of special characters
     ?assertEqual(<<"%20%09%0D%0A">>, klsn_binstr:urlencode(<<" \t\r\n">>)),
     
-    %% Test encoding of chars from 32 to 126
-    BinStr = iolist_to_binary(lists:seq(32, 126)),
+    %% Test encoding all chars
+    BinStr = iolist_to_binary(lists:seq(0, 255)),
     Expect = <<
+        "%00%01%02%03%04%05%06%07%08%09%0A%0B%0C%0D%0E%0F%10",
+        "%11%12%13%14%15%16%17%18%19%1A%1B%1C%1D%1E%1F",
         "%20%21%22%23%24%25%26%27%28%29%2A%2B%2C-.%2F0123456789",
         "%3A%3B%3C%3D%3E%3F%40ABCDEFGHIJKLMNOPQRSTUVWXYZ%5B%5C%5D%5E"
-        "_%60abcdefghijklmnopqrstuvwxyz%7B%7C%7D~"
+        "_%60abcdefghijklmnopqrstuvwxyz%7B%7C%7D~",
+        "%7F%80%81%82%83%84%85%86%87%88%89%8A%8B%8C%8D%8E%8F%90%91%92",
+        "%93%94%95%96%97%98%99%9A%9B%9C%9D%9E%9F%A0%A1%A2%A3%A4%A5%A6",
+        "%A7%A8%A9%AA%AB%AC%AD%AE%AF%B0%B1%B2%B3%B4%B5%B6%B7%B8%B9%BA",
+        "%BB%BC%BD%BE%BF%C0%C1%C2%C3%C4%C5%C6%C7%C8%C9%CA%CB%CC%CD%CE",
+        "%CF%D0%D1%D2%D3%D4%D5%D6%D7%D8%D9%DA%DB%DC%DD%DE%DF%E0%E1%E2",
+        "%E3%E4%E5%E6%E7%E8%E9%EA%EB%EC%ED%EE%EF%F0%F1%F2%F3%F4%F5%F6",
+        "%F7%F8%F9%FA%FB%FC%FD%FE%FF"
     >>,
     ?assertEqual(Expect, klsn_binstr:urlencode(BinStr)),
     


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved URL encoding to correctly handle and percent-encode all single-byte binary values.

- **Tests**
  - Expanded test coverage to verify URL encoding for the entire byte range (0–255), ensuring accurate encoding of all possible byte values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->