### PR TITLE
klsn_map: add path/0 type; alias key/0 to it

### DIFF
--- a/src/klsn_map.erl
+++ b/src/klsn_map.erl
@@ -11,13 +11,17 @@
     ]).
 
 -export_type([
-        key/0
+        path/0
+      , key/0
     ]).
 
 %% A path into a nested map, represented as a list of keys. Example:
 %% [foo, bar, baz] first looks up foo in the outer map, then bar in
 %% the returned map, and finally baz.
--type key() :: [term()].
+-type path() :: [term()].
+
+%% Deprecated. I should have named it path.
+-type key() :: path().
 
 
 %% @doc


### PR DESCRIPTION
- Export new path/0 type for nested map paths
- Keep key/0 as deprecated alias for compatibility
- No functional changes; improves naming clarity

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Introduced a new `path` type to the public API for improved clarity and consistency.
  * The existing `key` type is now aliased to `path` for backward compatibility while maintaining a clearer type hierarchy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->