### PR TITLE
klsn_binstr: add uuid/0 (RFC 4122 v4) and basic format test

### DIFF
--- a/src/klsn_binstr.erl
+++ b/src/klsn_binstr.erl
@@ -6,6 +6,7 @@
       , from_any/1
       , replace/2
       , hash/1
+      , uuid/0
     ]).
 
 %% UTF-8 binary string used as the canonical textual representation across
@@ -132,4 +133,12 @@ hex_val(H) when $A =< H, H =< $F -> H - $A + 10;
 hex_val(H) when $a =< H, H =< $f -> H - $a + 10.
 
 
+-spec uuid() -> binstr().
+uuid() ->
+    <<R1:48, _:4, R2:12, _:2, R3:62>> = crypto:strong_rand_bytes(16),
+    <<U1:32, U2:16, U3:16, U4:16, U5:48>> = <<R1:48, 0:1, 1:1, 0:1, 0:1, R2:12, 1:1, 0:1, R3:62>>,
+    iolist_to_binary(io_lib:format(
+        "~8.16.0b-~4.16.0b-~4.16.0b-~4.16.0b-~12.16.0b",
+        [U1, U2, U3, U4, U5])
+    ).
 

--- a/test/klsn_binstr_tests.erl
+++ b/test/klsn_binstr_tests.erl
@@ -147,3 +147,17 @@ replace_edge_cases_test() ->
     ?assertEqual(LargeB, klsn_binstr:replace([{<<"a">>, <<"b">>}], LargeA)),
 
     ok.
+
+uuid_0_test() ->
+    ?assertMatch(<<
+        _:8/binary
+      , "-"
+      , _:4/binary
+      , "-"
+      , _:4/binary
+      , "-"
+      , _:4/binary
+      , "-"
+      , _:12/binary
+    >>, klsn_binstr:uuid()).
+


### PR DESCRIPTION
- Export `uuid/0` and implement random v4 UUID with correct version/variant bits
- Return lowercase hex with 8-4-4-4-12 grouping as binary
- Add eunit test to assert overall UUID shape

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added UUID generation functionality that produces standard 36-character UUID binary strings with the standard 8-4-4-4-12 hyphenated format.

* **Tests**
  * Added test coverage for the new UUID generation function to ensure correct output format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->