### PR TITLE
feat(klsn_map): add exists/2 helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,11 @@ Function
 -spec lookup(key(), map()) -> klsn:maybe(term()).
 ```
 
+### `klsn_map:exists/2`
+```
+-spec exists(key(), map()) -> boolean().
+```
+
 ### `klsn_map:upsert/3`
 ```
 -spec upsert(key(), term(), map()) -> map().

--- a/src/klsn_map.erl
+++ b/src/klsn_map.erl
@@ -4,6 +4,7 @@
         lookup/2
       , get/2
       , get/3
+      , exists/2
       , upsert/3
       , remove/2
       , filter/1
@@ -57,6 +58,13 @@ lookup([H|T], Map) ->
         error ->
             none
     end.
+
+%% @doc
+%% Return true when the path exists within the map, false otherwise.
+%% This is a boolean convenience wrapper around lookup/2.
+-spec exists(key(), map()) -> boolean().
+exists(Key, Map) ->
+    lookup(Key, Map) =/= none.
 
 %% @doc
 %% Insert or replace the element located at *Key* with *Value* inside

--- a/test/klsn_map_tests.erl
+++ b/test/klsn_map_tests.erl
@@ -139,3 +139,24 @@ remove_test() ->
     Map3 = #{a => 5},
     ?assertEqual(Map3, klsn_map:remove([a, x], Map3)).
 
+%% Tests for exists/2
+exists_test() ->
+    %% Base maps
+    Map = #{a => 1, b => 2},
+    NestedMap = #{c => #{d => 4}},
+    ComplexMap = #{a => 1, b => 2, c => NestedMap},
+
+    %% Empty path exists (refers to the whole value)
+    ?assert(klsn_map:exists([], Map)),
+
+    %% Existing keys / paths
+    ?assert(klsn_map:exists([a], Map)),
+    ?assert(klsn_map:exists([c, c, d], ComplexMap)),
+
+    %% Missing keys / paths
+    ?assertNot(klsn_map:exists([e], Map)),
+    ?assertNot(klsn_map:exists([c, e], ComplexMap)),
+
+    %% Non-map bases should not crash and should return false
+    ?assertNot(klsn_map:exists([a], not_a_map)),
+    ?assertNot(klsn_map:exists([a, b], #{a => not_a_map})).


### PR DESCRIPTION
- Export and implement exists/2 as a boolean wrapper over lookup/2
- Add exists_test() covering positive/negative and non-map cases
- Document klsn_map:exists/2 in README

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `exists/2` function to check if a key exists within a map, returning a boolean value. This expands the public API for map operations.

* **Documentation**
  * Updated documentation with specifications for the new `exists/2` function.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->